### PR TITLE
edits to section 3

### DIFF
--- a/paper_sections/03-hierarchical_gams.Rmd
+++ b/paper_sections/03-hierarchical_gams.Rmd
@@ -2,13 +2,13 @@
 
 ## What do we mean by hierarchical smooths?
 
-The smoothers in section II allowed us to model flexible relationships between our response and predictor variables. In this section, we will describe how to model model inter-group variability using smooth curves and how to fit these models in `mgcv`. Model structure is key in this framework, so we start with three choices:
+The smooths in section II allowed us to model flexible relationships between our response and predictor variables. In this section, we will describe how to model inter-group variability using smooth curves and how to fit these models in *mgcv*. Model structure is key in this framework, so we start with three choices:
 
 1. Should each group have its own smooth, or will a global smooth term suffice?
 
-2. Do all of the group-specific curves have the same smoothness, or should each group have its own smoothing parameter?
+2. Do all of the group-specific curves have the same wiggliness, or should each group have its own smoothing parameter?
 
-3. Will the smooths for each group have a similar shape to one another -- a shared average curve[^shape]?
+3. Will the smooths for each group have a similar shape to one another --- a shared average curve[^shape]?
 
 [^shape]: For this paper, we consider two functions to have similar shape if the
 average squared distance between the functions is small (assuming the functions
@@ -20,7 +20,7 @@ benefit of this definition of shape, however, is that it is straightforward to
 translate into quadratic penalties as we have been using. 
 
 
-These three choices result in five possible models (figure \ref{fig:models}), beyond the null model of "no relation between response and predictor(s)".:
+These three choices result in five possible models (figure \ref{fig:models}):
 
 1. A single common smooth for all observations.
 
@@ -37,27 +37,30 @@ These three choices result in five possible models (figure \ref{fig:models}), be
 ![\label{fig:models}Alternate types of functional variation f(x) that can be fitted with HGAMs. The dashed line indicates the average function value for all groups, and each solid line indicates the functional value at a given predictor value for an  individual group level.](../figures/alternate_models.png)
 
 
-It is important to note that "similar wiggliness" and "similar shape" are distinct ideas; two functions can have very similar wiggliness but very different shapes. Wiggliness simply measures how quickly a function changes across its range, and it is easy to construct two functions that differ in shape but have the same wiggliness. For example, a logistic curve might have the same squared total second derivative between -1 and +1 as a sine curve, but they have very different shapes. Figure \ref{fig:models}, model 4 illustrates this case. 
+It is important to note that "similar wiggliness" and "similar shape" are two distinct concepts; functions can have very similar wiggliness but very different shapes. Wiggliness simply measures how quickly a function changes across its range, and it is easy to construct two functions that differ in shape but have the same wiggliness. For example, a logistic curve might have the same squared total second derivative between -1 and +1 as a sine curve, but they have very different shapes. Figure \ref{fig:models}, model 4 illustrates this case. 
+
 Similarly, two curves could have very similar overall shape, but differ in their wiggliness. For instance, if one function was equal to the second function plus a high-frequency osscilation. Figure \ref{fig:models} model 3 illustrates this. 
 
-We will discuss the trade-offs between different models and guidelines about when each of these models is appropriate in section IV. The remainder of this section will focus on how to specify each of these five models using `mgcv`.
+We will discuss the trade-offs between different models and guidelines about when each of these models is appropriate in section IV. The remainder of this section will focus on how to specify each of these five models using *mgcv*.
 
 ## Coding hierarchical GAMs in R
 
 **EJP: Going with canned and simulated data for the examples rather than real as it's a bit less messy**
 
-Each of these models can be coded straightforwardly in `mgcv`. To help illustrate this throughout the section when describing how to set these models up, we will refer to the response variable as $y$,  continuous predictor variables as $x$ (or $x_1$ and  $x_2$, in the case multiple predictors), and $\text{fac}$ to designate the discrete grouping factor whose variation we are interested in understanding.
+Each of these models can be coded straightforwardly in *mgcv*. To help illustrate this throughout the section when describing how to set these models up, we will refer to the response variable as $y$,  continuous predictor variables as $x$ (or $x_1$ and  $x_2$, in the case multiple predictors), and *fac* to designate the discrete grouping factor whose variation we are interested in understanding.
 
-We will also use two example datasets to demonstrate how to code these models (see the appendix for code to generate these examples):
+We will also use two example datasets to demonstrate how to code these models (see the appendix for code to reproduce these examples):
 
-A. The `CO2` dataset, available in R in the `datasets` package. This data is from an experimental study by @potvin_statistical_1990 of $\text{CO}_2$ uptake in grasses under varying concentrations of $\text{CO}_2$, measuring how concentration-uptake functions varied between plants from two locations (Mississippi and Quebec) and two temperature treatments (chilled and warm). A total of 12 plants were measured, and uptake measured at 7 concentration levels for each plant (figure \ref{fig:vis_data}a). Here we will focus on how to use these techniques to estimate inter-plant variation in functional responses.
+A. The `CO2` dataset, available in R via the `datasets` package. This data is from an experimental study by @potvin_statistical_1990 of $\text{CO}_2$ uptake in grasses under varying concentrations of C)~2~, measuring how concentration-uptake functions varied between plants from two locations (Mississippi and Quebec) and two temperature treatments (chilled and warm). Twelve plants were used and CO~2~ uptake measured at 7 CO~2~ concentrations for each plant (figure \ref{fig:vis_data}a). Here we will focus on how to use these HGAMs to estimate inter-plant variation in functional responses.
 
 B. A hypothetical study of what bird movement might look like along a migration corridor, sampled throughout the year. We have simulated this data for this paper (see supplemental code XX). This dataset consists of records of numbers of observed locations of 100 tagged individuals each from six species of bird, at ten locations along a latitudinal gradient, with one observation taken every four weeks. Not every bird was observed at each time point, so counts vary randomly between location and week. The data set (`bird_move`) consists of the variables `count`, `latitude`, `week` and `species` (figure \ref{fig:vis_data}b). This example will allow us to demonstrate how to fit these models with interactions and with non-normal (count) data.
 
 
-```{r vis_data, echo=FALSE,  fig.width=6, fig.height=3, cache=TRUE,fig.cap="\\label{fig:vis_data}Example data sets used throughout section III. a) Grass CO2 uptake versus CO2 concentration for 12 individual plants (black lines). b) Simulated data set of bird migration, with point size corresponding to weekly counts of 6 species along a latituidinal gradient (zeros excluded for clarity)."}
-library(mgcv)
-library(ggplot2)
+```{r vis_data, echo=FALSE,  fig.width=8, fig.height=4, out.width="\\linewidth", fig.cap="\\label{fig:vis_data}Example data sets used throughout section III. a) Grass $\\text{CO}\\textsubscript{2}$ uptake versus $\\text{CO}\\textsubscript{2}$ concentration for 12 individual plants (black lines). b) Simulated data set of bird migration, with point size corresponding to weekly counts of 6 species along a latituidinal gradient (zeros excluded for clarity)."}
+library("mgcv")
+library("ggplot2")
+library("cowplot")
+theme_set(theme_bw())
 
 #The default CO2 plant variable is ordered;
 #This recodes it to an unordered factor (see above for why).
@@ -66,32 +69,26 @@ CO2 <- transform(CO2, Plant_uo=factor(Plant, ordered=FALSE))
 #Loading simuated bird movement data
 bird_move <- read.csv("../data/bird_move.csv") 
 
-CO2_vis_plot = ggplot(CO2, aes(x=conc,y=uptake,group=Plant))+
-  geom_point()+
-  geom_line()+
-  labs(x="CO2 concentration", y= "CO2 uptake",title="CO2 uptake data")+
-  cowplot::theme_cowplot()
+CO2_vis_plot <- ggplot(CO2, aes(x=conc, y=uptake, group=Plant)) +
+  geom_point() +
+  geom_line() +
+  labs(x=expression(CO[2] ~ concentration ~ (mL ~ L^{-1})), y=expression(CO[2] ~ uptake ~ (mu*mol ~ m^{-2})))
 
-bird_vis_plot = ggplot(dplyr::filter(bird_move,count>0), aes(x=week,y=latitude,size= count))+
-  facet_wrap(~species)+
-  geom_point()+
-  scale_size()+
-  labs(title="Simulated bird migration data")+ 
-  cowplot::theme_cowplot()+
+bird_vis_plot <- ggplot(dplyr::filter(bird_move, count > 0),
+                        aes(x=week, y=latitude, size=count))+
+  facet_wrap(~ species) +
+  geom_point() +
+  scale_size(name = "Count", range = c(0.2, 3)) +
+  labs(x = "Week", y = "Latitude") +
   theme(legend.position = "bottom")
 
-cowplot::plot_grid(CO2_vis_plot, bird_vis_plot,nrow = 1,labels = c("a","b"))
-
-
-
-
+plot_grid(CO2_vis_plot, bird_vis_plot, nrow=1, labels=c("a","b"),
+          align = "hv", axis = "lrtb")
 ```
 
-It is important to note that the grouping variable should be coded in R as an unordered factor -- a character will raise an error and numeric will lead to a completely different model specification. Whether the factor is ordered or not will not matter for most of the smoothers we use here. However, for models 3&5 order will matter (see below for further details).
+It is important to note that the grouping variable should be coded in R as an unordered factor --- a character variable will raise an error and a numeric variable will lead to a completely different model specification. Whether the factor is ordered or not will not matter for most of the smooths we use here. However, for models 3 and 5, order will matter (see below for further details).
 
-Throughout the examples we use Restricted Maximum Likelihood (REML) to estimate model coefficients and smoothing parameters. We strongly recommend using either REML or marginal likelihood (ML) when fitting GAMs for the reasons outlined in [@wood_fast_2011].
-
-In each case some data processing and manipulation has been done to obtain the graphics and results below. We recommend readers take a look at the source RMarkdown [CITE] document for this paper to get the full code.
+Throughout the examples we use Restricted Maximum Likelihood (REML) to estimate model coefficients and smoothing parameters. We strongly recommend using either REML or marginal likelihood (ML) when fitting GAMs for the reasons outlined in [@wood_fast_2011]. In each case some data processing and manipulation has been done to obtain the graphics and results below. We recommend readers take a look at the source RMarkdown **[CITE]** document for this paper to get the full code.
 
 ### A single common smooth for all observations (Model 1)
 
@@ -116,26 +113,24 @@ where $\zeta_\texttt{Plant\_uo}$ is the random effect for plant and $\epsilon_i$
 
 In R we can write our model as:
 ```{r co2_mod1_unrun, echo=TRUE, eval=FALSE}
-CO2_mod1 <- gam(log(uptake) ~ s(log(conc), k = 5, bs = "tp") +
-                              s(Plant_uo, k = 12, bs = "re"),
+CO2_mod1 <- gam(log(uptake) ~ s(log(conc), k=5, bs="tp") +
+                              s(Plant_uo, k=12, bs="re"),
                 data=CO2, method="REML")
 ```
 
-This is the typical GAM setup, with a single smooth term for each variable. Specifying the model is similar to specifying a `glm` in R, with the addition of `s()` terms to include one-dimensional or isotropic multidimensional smooths. The first argument to `s()` is the terms to be smoothed, the type of smooth to be used for the term is specified by the `bs=...` argument, and the number of basis functions is specified by `k=...`.
+This is the typical GAM setup, with a single smooth term for each variable. Specifying the model is similar to specifying a GLM in R via `glm()`, with the addition of `s()` terms to include one-dimensional or isotropic multidimensional smooths. The first argument to `s()` are the terms to be smoothed, the type of smooth to be used for the term is specified by the `bs` argument, and the number of basis functions is specified by `k`[^k_note].
 
-```{r co2_mod1, echo=FALSE,  fig.width=6, fig.height=3, cache=TRUE,fig.cap="\\label{fig:co2_mod1}mgcv plotting output for model 1 applied to the CO2 dataset."}
+[^k_note]: Due to identifiability or other constraints (e.g.\ cyclic smooths) arising from the type of smoother, the actual number of basis functions used may be less than `k`.
+
+```{r co2_mod1, echo=FALSE,  fig.width=6, fig.height=3, dev.args=list(pointsize=10), fig.cap="\\label{fig:co2_mod1}mgcv plotting output for model 1 applied to the CO2 dataset."}
 library(mgcv)
 library(ggplot2)
-
-#The default CO2 plant variable is ordered;
-#This recodes it to an unordered factor (see above for why).
-CO2 <- transform(CO2, Plant_uo=factor(Plant, ordered=FALSE))
 
 CO2_mod1 <- gam(log(uptake) ~ s(log(conc), k=5, bs="tp") +
                               s(Plant_uo, k=12, bs="re"),
                 data=CO2, method="REML")
 
-plot(CO2_mod1, pages=1, seWithMean = TRUE)
+plot(CO2_mod1, pages=1, seWithMean=TRUE)
 ```
 
 Figure \ref{fig:co2_mod1} illustrates `mgcv'`s default plotting out for `CO2_mod1`: the left panel shows the estimated global functional relationship, and the right shows a quantile-quantile plot of the estimates effects vs Guassian quantiles, which can be used to check our model.
@@ -144,8 +139,9 @@ Figure \ref{fig:co2_mod1} illustrates `mgcv'`s default plotting out for `CO2_mod
 
 Looking at the effects by term is useful but we are often interested in fitted values or predictions our models. This can be useful to construct plots (like those in Figure \ref{fig:co2_mod1_predict}). The next block of code shows how you could plot this to illustrate inter-plant variation in the functional response, plotting untransformed uptake and concentration to make the figure easier to interpret. 
 
+```{r co2_mod1_ggplot, fig.width=6, fig.height=4, fig.cap="\\label{fig:co2_mod1_predict}", out.width="\\linewidth"}
+theme_set(theme_bw())
 
-```{r co2_mod1_ggplot, fig.width=6, fig.height=3, fig.cap="\\label{fig:co2_mod1_predict}"
 # setup prediction data
 CO2_mod1_pred <- with(CO2,
                       expand.grid(conc=seq(min(conc), max(conc), length=100),
@@ -157,66 +153,63 @@ CO2_mod1_pred <- cbind(CO2_mod1_pred,
 
 # make the plot
 ggplot(data=CO2, aes(x=conc, y=uptake, group=Plant_uo)) +
-    facet_wrap(~Plant_uo) +
-    geom_point() +
-    geom_line(aes(y=exp(fit)), data=CO2_mod1_pred) +
-    geom_ribbon(aes(ymin=exp(fit - 2*se.fit), ymax=exp(fit + 2*se.fit), x=conc),
-                data=CO2_mod1_pred, alpha=0.3, inherit.aes=FALSE)
+  facet_wrap(~Plant_uo) +
+  geom_point() +
+  geom_line(aes(y=exp(fit)), data=CO2_mod1_pred) +
+  geom_ribbon(aes(ymin=exp(fit - 2*se.fit), ymax=exp(fit + 2*se.fit), x=conc),
+              data=CO2_mod1_pred, alpha=0.3, inherit.aes=FALSE) +
+  labs(x=expression(CO[2] ~ concentration ~ (mL ~ L^{-1})),
+       y=expression(CO[2] ~ uptake ~ (mu*mol ~ m^{-2})))
 ```
 
-We can include interactions in an `s()` term via isotropic smooths such as thin plate regression splines or we can use the tensor product (`te()`) function, if we don't believe the composite terms are isotropic. In this case `bs` and `k` can be specified as a single value (in which case each marginal smooth has the same basis or complexity) or as a vector of basis types or complexities. For example, `y~te(x1,x2, k=c(10,5), bs=c("tp","cs"))`, would specify a non-isotropic smooth of `x1` and `x2`, with the marginal basis for `x1` being a thin plate regression spline with 10 basis functions, and the smooth of `x2` being a cubic regression spline with a penalty on the null space.
+We can include interactions in an `s()` term via isotropic smooths such as TPRSs or we can use the tensor product (`te()`) function, if we don't believe the composite terms are isotropic. In this case `bs` and `k` can be specified as a single value (in which case each marginal smooth has the same basis or complexity) or as a vector of basis types or complexities. For example, `y ~ te(x1,x2, k=c(10,5), bs=c("tp","cs"))`, would specify a non-isotropic tensor product smooth of `x1` and `x2`, with the marginal basis for `x1` being a thin plate regression spline with 10 basis functions, and the smooth of `x2` being a cubic regression spline with 5 basis functions and a penalty on the null space.
 
 For our bird example, we want to look at the interaction between location and time, so for this we setup the model as:
 
 $$
-\texttt{count}_i = \exp(f(\texttt{week}_i, \texttt{latitude}_i))
+\mathbb{E}(\texttt{count}_i) = \exp(f(\texttt{week}_i, \texttt{latitude}_i))
 $$
 
-where we assume that $\texttt{count}_i \sim\text{Poisson}$. For the smooth term, $f$, we employ a tensor product of latitude and week, using a thin plate regression spline for the marginal latitude effects, and a cyclic cubic spline for the marginal week effect to account for the cyclic nature of weekly effects (we expect week 1 and week 52 to have very similar values), both splines had basis complexity (`k`) of 10. We will also assume the counts of individuals at each location in each week follow a Poisson distribution, and we will ignore
-species-specific variability. 
+where we assume that $\texttt{count}_i \sim\text{Poisson}$. For the smooth term, $f$, we employ a tensor product of `latitude` and `week`, using a TPRS for the marginal latitude effects, and a cyclic cubic regression spline for the marginal week effect to account for the cyclic nature of weekly effects (we expect week 1 and week 52 to have very similar values), both splines had basis complexity (`k`) of 10. We will also assume the counts of individuals at each location in each week follow a Poisson distribution, and we will ignore species-specific variability. 
 
-```{r bird_mod1, fig.width = 4, fig.height = 4, fig.cap="\\label{fig:bird_mod1}The default plot for this GAM illustrates the average log-abundance of all bird species at each latitude for each week, with yellow colours indicating more individuals and red colours fewer."}
+```{r bird_mod1, fig.width = 4, fig.height = 4, outwidth="\\linewidth", dev.args = list(pointsize=10), fig.cap="\\label{fig:bird_mod1}The default plot for this GAM illustrates the average log-abundance of all bird species at each latitude for each week, with yellow colours indicating more individuals and red colours fewer."}
 library(tidyr)
 library(viridis) # for color plotting
 
 bird_move <- read.csv("../data/bird_move.csv") # load data
 
 bird_mod1 <- gam(count ~ te(week, latitude, bs=c("cc", "tp"), k=c(10, 10)),
-                 data=bird_move, method="REML", family=poisson)
+                 data=bird_move, method="REML", family=poisson,
+                 knots = list(week = c(0.5, 52.5)))
 
 plot(bird_mod1, pages=1, scheme=2, rug=FALSE)
 box()
 ```
 
-Figure \ref{fig:bird_mod1} shows birds starting at low latitudes in the winter then migrating to high latitudes from the 10th to 20th week, staying there for 15-20 weeks, then migrating back. However, the plot also indicates a large amount of variability in the timing of migration. The source of this variability is apparent when looking at the specifics of migration timing of each species (figure \ref{fig:vis_data}b). 
+Figure \ref{fig:bird_mod1} shows birds starting at low latitudes in the winter then migrating to high latitudes from the 10th to 20th week, staying there for 15-20 weeks, then migrating back. However, the plot also indicates a large amount of variability in the timing of migration. The source of this variability is apparent when we look at the timing of migration of each species (figure \ref{fig:vis_data}b). 
 
-All six species in figure \ref{fig:vis_data}b) show relatively precise migration patterns, but they differ in the timing of when they leave their winter grounds and the time they spend at their summer grounds. Averaging over all of this variation results in a relatively imprecise (diffuse) average estimate of migration timing (figure \ref{fig:bird_mod1}, \ref{fig:bird-fitted-mod1}), and viewing species-specific plots of observed versus predicted values (figure \ref{fig:bird-fitted-mod1}), it is appearent that the model fits some of the species better than others. This model could potentially be improved by adding inter-group variation in migration timing. The rest of this section will focus on how to model this type of variation. 
+All six species in figure \ref{fig:vis_data}b) show relatively precise migration patterns, but they differ in the timing of when they leave their winter grounds and the amount of time they spend at their summer grounds. Averaging over all of this variation results in a relatively imprecise (diffuse) average estimate of migration timing (figure \ref{fig:bird_mod1}, \ref{fig:bird-fitted-mod1}), and viewing species-specific plots of observed versus predicted values (figure \ref{fig:bird-fitted-mod1}), it is appearent that the model fits some of the species better than others. This model could potentially be improved by adding inter-group variation in migration timing. The rest of this section will focus on how to model this type of variation. 
 
-```{r bird-fitted-mod1,fig.cap="\\label{fig:bird-fitted-mod1}Observed counts by species versus predicted counts from bird_mod1 (1-1 line added as reference). If our model fitted well we would expect that all species should show similiar dispersions around the 1-1 line. Instead we see that variance around the predicted is much higher for species 1 and 6."}
-bird_move$mod1 = predict(bird_mod1, type="response")
+```{r bird-fitted-mod1, fig.width=6, fig.height=4, out.width="\\linewidth", fig.cap="\\label{fig:bird-fitted-mod1}Observed counts by species versus predicted counts from \\texttt{bird\\_mod1} (1-1 line added as reference). If our model fitted well we would expect that all species should show similiar dispersions around the 1-1 line. Instead we see that variance around the predicted is much higher for species 1 and 6."}
+bird_move <- transform(bird_move, mod1 = predict(bird_mod1, type="response"))
 
-ggplot(bird_move, aes(x=mod1, y= count))+
-  facet_wrap(~species)+
-  geom_point()+
-  geom_abline()+
-  labs(x="Predicted counts (model 1)", y= "Observed bird counts")+
-  cowplot::theme_cowplot()
-
+ggplot(bird_move, aes(x=mod1, y=count)) +
+  facet_wrap(~species) +
+  geom_point() +
+  geom_abline() +
+  labs(x="Predicted count (model 1)", y= "Observed count") +
+  theme_bw()
 ```
-
-
 
 ### A single common smooth plus group-level smooths that have the same wigglyness (Model 2)
 
+Model 2 is a close analogue to a GLMM with varying slopes: all groups have similar functional responses, but inter-group variation in responses is allowed. This approach works by allowing each grouping level to have its own functional response, but penalizing functions that are too far from the average.
 
-Model 2 is a close analogue to a GLMM with varying slopes: all groups have similar functional responses, but allows for inter-group variation in responses. This approach works by allowing each grouping level to have its own functional response, but penalizing functions that are too far from the average.
+This can be coded in *mgcv* by explicitly specifying one term for the global smooth (as in model 1 above) then adding a second smooth term specifying the group level smooth terms, using a penalty term that tends to draw these group-level smooths to zero. For one-dimensional smooths, *mgcv* provides an explicit basis type to do this, the factor smooth or `"fs"` basis (see `?smooth.construct.fs.smooth.spec` for detailed notes). This smoother creates a copy of each set of basis functions for each level of the grouping variable, but only estimates one set of smoothing parameters for all groups. The penalty is also set up so each component of its null space is given its own penalty (so that all components of the smooth are penalized towards zero)[^intercept_note]. As there can be issues of co-linearity between the global smooth term and the group-specific terms (see section V for more details), it is generally necessary to use a smoother with a more restricted null space than the global smooth; for thin plate splines this can be done by setting `m=2` for the global smooth and `m=1` for the group smooth [@baayen_autocorrelated_2016] [also cite Wieling paper here]. e.g.: `y~s(x,bs="tp",m=2)+s(x,fac,bs="fs",m=1,xt=list(bs="tp"))`.
 
-This can be coded in `mgcv` by explicitly specifying one term for the global smooth (as in model 1 above) then adding a second smooth term specifying the group level smooth terms, using a penalty term that tends to draw these group-level smooths to zero. For one-dimensional smooths, `mgcv` provides an explicit basis type to do this, the factor smooth or "fs" basis (see `?smooth.construct.fs.smooth.spec` for detailed notes). This smoother creates a copy of each set of basis functions for each level of the grouping variable, but only estimates one set of smoothing parameters for all groups. The penalty is also set up so each component of its null space is given its own penalty (so that all components of the smooth are penalized towards zero)[^intercept_note]. As there can be issues of co-linearity between the global smooth term and the group-specific terms (see section V for more details), it is generally necessary to use a smoother with a more restricted null space than the global smooth; for thin plate splines this can be done by setting m=2 for the global smooth and m=1 for the group smooth [@baayen_autocorrelated_2016] [also cite Wieling paper here]. e.g.: `y~s(x,bs="tp",m=2)+s(x,fac,bs="fs",m=1,xt=list(bs="tp"))`. 
-
-
+**GLS: I'm not convinced this `m` thing is the right way to gofor `"fs"` smooths. Compare the model with `m=1` vs `m=2` on the `bs="fs"` term. You'll see that with `m=1` the subject-specific smooths are in some instances piece-wise linear. This model uses ~42 EDF for the `"fs"` part. The `m=2` version uses about 31 EDF (IIRC). The range of the y-axis on the global smooth plot is a little larger, but not by much, but how much is this increased uncertainty in the estimate of the global smooth and how much is changes in the shape of this smooth? Also, it is not much of a change, at the saving of ~10 EDF over the `m=1` model.**
 
 [^intercept_note]: As part of the penalty construction, each group will also have its own intercept (part of the penalized null space), so there is no need to add a separate term for group specific intercepts as we did in model 1.
-
 
 We modify our previous $\text{CO}_2$ model as follows:
 
@@ -226,16 +219,8 @@ $$
 
 where $f_{\texttt{Plant\_uo}_i}(\log_e(\texttt{conc}_i))$ is the smooth of concentration for the given plant. In R we then have:
 
-```{r co2_mod2-norun, eval=FALSE}
-CO2_mod2 <- gam(log(uptake) ~ s(log(conc), k=5, m=2, bs="tp") +
-                              s(log(conc), Plant_uo, k=5,  bs="fs", m=1),
-                data=CO2, method="REML")
-```
-
-```{r co2_mod2, fig.width=6, fig.height=3, fig.cap="\\label{fig:co2_mod2}Global function (left) and group-specific deviations from the global function (right) for CO2_mod2"}
-source("../code/functions.R")
-
-CO2_mod2 <- gam(log(uptake) ~ s(log(conc), k=5, m=2, bs="tp") +
+```{r co2_mod2, fig.width=6, fig.height=3, dev.args=list(pointsize=10), out.width="\\linewidth", echo=FALSE, fig.cap="\\label{fig:co2_mod2}Global function (left) and group-specific deviations from the global function (right) for \\texttt{CO2\\_mod2}"}
+CO2_mod2 <- gam(log(uptake) ~ s(log(conc), k=5, m=2) +
                               s(log(conc), Plant_uo, k=5,  bs="fs", m=1),
                 data=CO2, method="REML")
 
@@ -244,125 +229,122 @@ plot(CO2_mod2, page=1, seWithMean=TRUE)
 
 Figure \ref{fig:co2_mod2} shows the fitted smoothers for `CO2_mod2`. The plots of group-specific smooths indicate that plants differ not only in average log-uptake (which would correspond to each plant having a straight line at different levels for the group-level smooth), but differ slightly in the shape of their functional responses. Figure \ref{fig:co2_mod2_pred} shows how the global and group-specific smooths combine to predict uptake rates for individual plants:
 
-```{r co2_mod2_ggplot,echo=FALSE, fig.width=6, fig.height=3, fig.cap="\\label{fig:co2_mod2_pred}Predicted uptake values (lines) verus oberved uptake for each plant, based on CO2 model 2."}
+```{r co2_mod2_ggplot,echo=FALSE, fig.width=6, fig.height=4, out.width="\\linewidth", fig.cap="\\label{fig:co2_mod2_pred}Predicted uptake values (lines) versus observed uptake for each plant, based on model 2."}
 CO2_mod2_pred <- predict(CO2_mod2, se.fit=TRUE)
-CO2$mod2 <- CO2_mod2_pred$fit
-CO2$mod2_se <- CO2_mod2_pred$se.fit
+CO2 <- transform(CO2, mod2 = CO2_mod2_pred$fit, mod2_se = CO2_mod2_pred$se.fit)
 
 ggplot(data=CO2, aes(x=conc, y=uptake, group=Plant_uo)) +
   facet_wrap(~Plant_uo) +
   geom_point() +
   geom_line(aes(y=exp(mod2))) +
   geom_ribbon(aes(ymin=exp(mod2-2*mod2_se),
-                  ymax=exp(mod2+2*mod2_se)), alpha=0.25)
+                  ymax=exp(mod2+2*mod2_se)), alpha=0.25) +
+  labs(x=expression(CO[2] ~ concentration ~ (mL ~ L^{-1})),
+       y=expression(CO[2] ~ uptake ~ (mu*mol ~ m^{-2}))) +
+  theme_bw()
 ```
 
-The "`fs`"-based approach mentioned above does not work for higher-dimensional tensor product smooths (if one is willing to use thin plate regression splines for the multivariate smooth then one can use "`fs`"). Instead, the group-specific term can be specified with a tensor product of the continuous smooths and a random effect for the grouping parameter. This term will again have a separate set of basis functions for each group, one penalty for the smooth term, and a second penalty drawing all basis functions toward zero[^fs_note]. e.g.: `y~te(x1,x2,bs="tp",m=2)+te(x1,x2, fac,bs=c("tp","tp","re"),m=1)`. We illustrate this approach below on the bird migration data. 
+The `"fs"`-based approach mentioned above does not work for higher-dimensional tensor product smooths (if one is willing to use thin plate regression splines for the multivariate smooth then one can use `"fs"`). Instead, the group-specific term can be specified with a tensor product of the continuous smooths and a random effect for the grouping parameter. This term will again have a separate set of basis functions for each group, one penalty for the smooth term, and a second penalty drawing all basis functions toward zero[^fs_note]. e.g.: `y ~ te(x1, x2, bs="tp", m=2) + t2(x1, x2, fac, bs=c("tp","tp","re"), m=1, full=TRUE)`. We illustrate this approach below on the bird migration data. 
 
+[^fs_note]: Note that this differs from the `"fs"` penalty, which assigned one penalty per null space term. **GLS: check this is true now that I have moved to the `t2()` basis as per example in `?smooth.construct.fs.smooth.spec`, which I understand to be exactly equivalent to what `"fs"` is doing**
 
-[^fs_note]: Note that this differs from the "fs" penalty, which assigned one penalty per null space term.
-
-```{r bird_mod2, fig.width=4, fig.height=4}
+```{r bird_mod2}
 bird_mod2 <- gam(count ~ te(week, latitude, bs=c("cc", "tp"),
                             k=c(10, 10), m=c(2, 2)) +
-                         te(week, latitude, species, bs=c("cc", "tp", "re"),
-                            k=c(10, 10, 6), m=c(1, 1, 1)),
+                         t2(week, latitude, species, bs=c("cc", "tp", "re"),
+                            k=c(10, 10, 6), m=c(1, 1, 1), full=TRUE),
                  data=bird_move, method="REML", family=poisson)
-
 ```
 
+```{r bird_mod2_ggplot, fig.width=8, fig.height=4, echo=FALSE, out.width="\\linewidth", fig.cap="\\label{fig:bird_mod2}a) Predicted migration paths for each species based on \\texttt{bird\\_mod2}, with lighter colors corresponding to higher predicted counts. b) Observed counts versus predictions from \\texttt{bird\\_mod2}."}
+bird_move <- transform(bird_move, mod2 = predict(bird_mod2, type="response"))
 
-
-```{r bird_mod2_ggplot, fig.width=8, fig.height=3, echo=FALSE, fig.cap="\\label{fig:bird_mod2}a) Predicted migration paths for each species based on bird_mod2, with lighter colors corresponding to higher predicted counts. b) Observed counts versus predictions from bird_mod2."}
-bird_move$mod2 <- predict(bird_mod2, type="response")
-
-bird_mod2_indiv = ggplot(data=bird_move, aes(x=week, y=latitude, fill=mod2)) +
+bird_mod2_indiv <- ggplot(data=bird_move, aes(x=week, y=latitude, fill=mod2)) +
   geom_tile(size=1) +
-  facet_grid(.~species) +
-  scale_fill_viridis("predicted count") +
+  facet_wrap(~ species, ncol=6) +
+  scale_fill_viridis("Count") +
   scale_x_continuous(expand=c(0, 0), breaks=c(1, 26, 52)) +
-  scale_y_continuous(expand=c(0, 0), breaks=c(0, 30, 60))+
-  cowplot::theme_cowplot()+
-  theme(legend.position="bottom")
+  scale_y_continuous(expand=c(0, 0), breaks=c(0, 30, 60)) +
+  labs(x = "Week", y = "Latitude") +
+  theme_bw() +
+  theme(legend.position="right")
   
-bird_mod2_indiv_fit = ggplot(data=bird_move, aes(x=mod2, y=count)) +
-  facet_grid(.~species) +
-  geom_point()+
-  geom_abline()+
-  labs(x="Predicted counts (model 2)", y= "Observed\ncounts")+
-  cowplot::theme_cowplot()
+bird_mod2_indiv_fit <- ggplot(data=bird_move, aes(x=mod2, y=count)) +
+  facet_wrap(~ species, ncol=6) +
+  geom_point() +
+  geom_abline() +
+  labs(x="Predicted count (model 2)", y= "Observed count") +
+  theme_bw()
   
-cowplot::plot_grid(bird_mod2_indiv,bird_mod2_indiv_fit, ncol=1,  align="v", 
-                   labels=c("a","b"),rel_heights= c(1.25,1))
-  
+plot_grid(bird_mod2_indiv, bird_mod2_indiv_fit, ncol=1, align="vh", axis = "lrtb", 
+          labels=c("a","b"), rel_heights= c(1,1))
 ```
 
 Model 2 is able to effectively capture the observed patterns of interspecific 
 variation in migration behaviour (figure \ref{fig:bird_mod2}a), shows a much 
-tigher fit between observed and predicted values, as well as less evidence of 
-over-dispersion in some species compared to model 1 (figure \ref{fig:bird_mod2}b). 
+tigther fit between observed and predicted values, as well as less evidence of 
+over-dispersion in some species compared to model 1 (figure \ref{fig:bird_mod2}b).
 
 ### A single common smooth plus group-level smooths with differing wigglyness (Model 3)
 
-
 This model class is very similar to model 2, but we now allow each group-specific smooth to have its own smoothing parameter and hence it's own level of wigglyness. This increases the computational cost of the model, and means that the only information shared between groups is through the global smoothing term. This is useful if different groups differ substantially in how variable they are.
 
-Fitting a seperate smooth term (with its own penalties) can be done in `mgcv` by using the `by=fac` argument in the `s()` function. Therefore, we can code this model as: `y~s(x,bs="tp") + s(x, by=fac, m=1, bs= "ts") + s(fac, bs="re")`. Note two major differences from how model 2 was specified: 1., we explicitly include a random effect for the intercept (the `bs="re"` term), as group-specific intercepts are not incorporated into these smooth terms automatically (as would be the case with `bs="fs"` or a tensor product random effect); 2., we explicitly use a basis with a fully penalized null space for the group-level smooth (`bs="ts"`, for  "thin plate with shrinkage"), as this method does not automatically penalize the nullspace, so there is potential for co-linearity issues between unpenalized components of the global and group-level smoothers.
+Fitting a seperate smooth term (with its own penalties) can be done in *mgcv* by using the `by` argument in the `s()` and `te()` (and related) functions. Therefore, we can code this model as: `y ~ s(x,bs="tp") + s(x, by=fac, m=1, bs="ts") + s(fac, bs="re")`. Note two major differences from how model 2 was specified: i) a random effect for the intercept (the `bs="re"` term) is explicitly included as group-specific intercepts are not incorporated into factor `by` variable smooths (as would be the case with `bs="fs"` or a tensor product random effect); and ii), we explicitly use a basis with a fully penalized null space for the group-level smooth (`bs="ts"`, for TPRS with shrinkage), as this method does not automatically penalize the null space, so there is potential for co-linearity issues between unpenalized components of the global and group-level smoothers.
 
 Our `CO2` model is then modified as follows:
 
 ```{r mod3_CO2-norun, eval=FALSE}
-CO2_mod3 = gam(log(uptake) ~ s(log(conc), k=5, m=2, bs="tp") +
-                             s(log(conc), by= Plant_uo, k=5, bs="ts", m=1) +
-                             s(Plant_uo, bs="re", k=12),
-               data= CO2, method="REML")
+CO2_mod3 <- gam(log(uptake) ~ s(log(conc), k=5, m=2, bs="tp") +
+                              s(log(conc), by=Plant_uo, k=5, m=1, bs="ts") +
+                              s(Plant_uo, bs="re", k=12),
+                data=CO2, method="REML")
 ```
 
 ```{r mod3_CO2, fig.width=5, fig.height=3, echo=FALSE, fig.cap="\\label{fig:co2_mod3}Functional relationships for the CO2 data estimated for model 3. Top left: the global smooth; Top middle: species-specific random effect intercepts. The remaining plots are a selected subset of the plant-specific smoothers, indicating how the functional response of that plant differs from the global smooth."}
-CO2_mod3 = gam(log(uptake) ~ s(log(conc), k=5, m=2, bs="tp") +
-                             s(log(conc), by= Plant_uo, k=5, bs="ts", m=1) +
-                             s(Plant_uo, bs="re", k=12),
-               data= CO2, method="REML")
+CO2_mod3 <- gam(log(uptake) ~ s(log(conc), k=5, m=2, bs="tp") +
+                              s(log(conc), by= Plant_uo, k=5, m=1, bs="ts") +
+                              s(Plant_uo, bs="re", k=12),
+                data=CO2, method="REML")
 
-par(mfrow=c(2, 3), mar =c(4, 4, 1, 1))
-plot(CO2_mod3, scale=0, select=1, ylab="global smooth", seWithMean=TRUE)
-plot(CO2_mod3, scale=0, select=14, ylab="Intercepts", main=NA)
-plot(CO2_mod3, scale=0, select=3, ylab="Plant Qn1", seWithMean=TRUE)
-plot(CO2_mod3, scale=0, select=5, ylab="Plant Qc1", seWithMean=TRUE)
-plot(CO2_mod3, scale=0, select=10, ylab="Plant Mn1", seWithMean=TRUE)
-plot(CO2_mod3, scale=0, select=13, ylab="Plant Mc1", seWithMean=TRUE)
+op <- par(mfrow=c(2, 3), mar =c(4, 4, 1, 1))
+plot(CO2_mod3, scale=0, select=1,  ylab="Global smooth", seWithMean=TRUE)
+plot(CO2_mod3, scale=0, select=14, ylab="Intercept",     main=NA)
+plot(CO2_mod3, scale=0, select=3,  ylab="Plant Qn1",     seWithMean=TRUE)
+plot(CO2_mod3, scale=0, select=5,  ylab="Plant Qc1",     seWithMean=TRUE)
+plot(CO2_mod3, scale=0, select=10, ylab="Plant Mn1",     seWithMean=TRUE)
+plot(CO2_mod3, scale=0, select=13, ylab="Plant Mc1",     seWithMean=TRUE)
+par(op)
 ```
 
 Figure \ref{fig:co2_mod3} shows a subsample of the group-specific smooths from this model, to prevent crowding. It is appearent from this that some groups (e.g. `Qc1`) have very similar shapes to the global smooth (differing only in intercept), others do differ from the global trend, with higher uptake at low concentrations and lower uptake at higher concentrations (e.g. `Mc1`, `Qn1`), or the reverse pattern (e.g. `Mn1`).
 
-Using model 3 with higher-dimensional data is also straightforward; `by=fac` terms work as well in tensor-product smooths as they do with isotrophic smooths. We can see this with our bird model:
+Using model 3 with higher-dimensional data is also straightforward; `by` terms work just as well in tensor-product smooths as they do with isotrophic smooths. We can see this with our bird model:
 
 
-```{r mod3_bird, fig.width=5, fig.height=3}
+```{r mod3_bird}
 bird_mod3 <- gam(count ~ te(week, latitude, bs=c("cc", "tp"),
                             k=c(10, 10), m=c(2, 2)) +
-                         te(week, latitude, bs= c("cc", "tp"),
-                            k=c(10, 10), m=c(1, 1), by=species),
+                         te(week, latitude, by=species, bs= c("cc", "ts"), # want shrinkage right?
+                            k=c(10, 10), m=c(1, 1)),
                  data=bird_move, method="REML", family=poisson)
 ```
 
-The fitted model for bird_mod3 is visually indistinguishable from bird_mod2 (figure \ref{fig:bird_mod2}} so we do not illustrate it here. 
+The fitted model for `bird_mod3` is visually indistinguishable from `bird_mod2` (figure \ref{fig:bird_mod2}) so we do not illustrate it here. 
 
 ### Models without global smooth terms (models 4 and 5)
 
 We can modify the above models to exclude the global term (which is generally faster; see section V). When we don't model the global term, we are allowing each factor to be different, though there may be some similarities in the shape of the functions.
 
-
 #### Model 4:
 
 Model 4 (shared smooths) is simply model 2 without the global smooth term: `y~s(x,fac,bs="fs")` or `y~te(x1,x2,fac,bs=c("tp","tp","re")`. This model assumes all groups have the same smoothness, but that the individual shapes of the smooth terms are not related. (Plots are very similar to model 2.)
 
-```{r mod4, fig.width=6, fig.height=3}
-CO2_mod4 <- gam(log(uptake) ~ s(log(conc), Plant_uo, k=5,  bs="fs", m=2),
+```{r mod4}
+CO2_mod4 <- gam(log(uptake) ~ s(log(conc), Plant_uo, k=5,  bs="fs"),
                 data=CO2, method="REML")
 
-bird_mod4 <- gam(count ~ te(week, latitude, species, bs=c("cc", "tp", "re"),
-                            k=c(10, 10, 6), m=2),
+bird_mod4 <- gam(count ~ t2(week, latitude, species, bs=c("cc", "tp", "re"),
+                            k=c(10, 10, 6)),
                  data=bird_move, method="REML", family=poisson)
 ```
 
@@ -370,14 +352,16 @@ bird_mod4 <- gam(count ~ te(week, latitude, species, bs=c("cc", "tp", "re"),
 
 Model 5 is simply model 3 without the first term: `y~s(x,by=fac)` or `y~te(x1,x2, by=fac)`. (Plots are very similar to model 3.)
 
-```{r mod5, fig.width=6, fig.height=3}
-CO2_mod5 <- gam(log(uptake) ~ s(log(conc), by=Plant_uo, k=5, bs="tp", m=2) +
-                              s(Plant_uo, bs="re", k=12), data= CO2, method="REML")
+```{r mod5}
+CO2_mod5 <- gam(log(uptake) ~ s(log(conc), by=Plant_uo, k=5) +
+                              s(Plant_uo, bs="re", k=12),
+                data= CO2, method="REML")
 
-bird_mod5 <- gam(count ~ te(week,latitude, by=species, bs= c("cc", "tp"),
-                            k=c(10, 10), m = 2),
+## assume we want shrinkage here?
+bird_mod5 <- gam(count ~ te(week, latitude, by=species, bs= c("cc", "ts"),
+                            k=c(10, 10)),
                  data=bird_move, method="REML", family=poisson)
 ```
 
-Where group-level smooths are coded using the `by=fac` argument in the `s()` function, ; if the factor is unordered, `mgcv` will set up a model with one smooth for each grouping level. If the factor is ordered, `mgcv` will not set the basis functions for the first grouping level to zero. In model 3 (with an ungrouped smooth included) the ungrouped smooth will then correspond to the first grouping level, rather than the average functional response, and the group-specific smooths will correspond to deviations from the first group. In model 5, using an ordered factor will result in the first group not having a smooth term associated with it at all.
+**GLS: this seems a little outof place here? Needs a better segue into it is it stays here and we need a model/formula example!** Where group-level smooths are coded using the `by` argument if the factor is unordered, *mgcv* will set up a model with one smooth for each grouping level. If the factor is ordered, *mgcv* will not set the basis functions for the first grouping level to zero. In model 3 (with an ungrouped smooth included) the ungrouped smooth will then correspond to the first grouping level, rather than the average functional response, and the group-specific smooths will correspond to deviations from the first group. In model 5, using an ordered factor will result in the first group not having a smooth term associated with it at all.
 


### PR DESCRIPTION
This is quite a big edit and a number of issues have cropped up. Anyway, this PR applies some minor text edits. I also fixed up a lot of the figures so they don't use *cowplot*s theme (beside being hideous, the base font size is huge producing cartoony plots). This change of theme is now more consistent with earlier sections but has been done at the expense of adding `+ theme_bw()` everywhere. I can set this in one location once the paper and examples settle down; at the moment I think there's still some modelling issues to consider before we set the code in place and therefore you may be running isolated bits of code so I left in the extraneous `library()` calls etc.

Ok, the biggies.

1. I'm still not convinced you need `m=1` on the subject-specific smooths with the `"fs"` basis. I have left it as is here, but if you set it to `m=2` (or leave it at the default), for the CO2 example, the subject-specific smooths use only 31 EDF, where as now they use ~42 EDF and several of them look piece-wise linear, not very smooth. Yes, you get slightly wider confidence interval on the global smooth, but some of this is due to it being a little more complex so the axis limits change a little because of the slight change in shape not just because the interval is wider. Is it worth 10+ degrees of freedom for slightly more precise estimate of the global smooth?

    Can we all take a look at this or weigh in? I'm going to run the code separately from the manuscript and prepare more of a comparison (I wanted to get edits done and submitted), but if others have input (I know on Twitter that all three of us chimed in when Ben Bolker was asking something similar) let's collate discussion here before settling on an approach for the paper.

2. Instead of `te()` terms for multivariate subject-specific random smooths in models 2 and 4, I have switched to the `t2(...., full = TRUE)` constructor. I seems from `?smooth.construct.fs.smooth.spec` that this should be exactly equivalent to `fs` in the 1D case, i.e.

        s(x) + s(x, fac, bs = "fs")

    is the same as

        t2(x, fac, bs = c("tp", "re"), full = TRUE)

    ignoring any `m` bits for now.

    So, I have gone for `t2(week, latitude, species, bs = c("cc", "tp", "re"), full = TRUE)` for the subject specific smooths in the bird example.

    Thoughts?

3. For the `by` variable smooths, do we always want shrinkage on the TPRS term? For the bird model examples, we had dropped this shrinkage yet Eric, you'd made a point of highlighting this in the text for the CO2 example for models 3 and 5. I have added shrinkage to the Latitude marginal smooth in these examples on the assumption that if we wanted it for the CO2 example we want it for the bird one too.

    Thoughts?